### PR TITLE
Typo in XSS prevention

### DIFF
--- a/2017/en/0xa7-xss.md
+++ b/2017/en/0xa7-xss.md
@@ -19,7 +19,7 @@ Typical XSS attacks include session stealing, account takeover, MFA bypass, DIV 
 
 Preventing XSS requires separation of untrusted data from active browser content.
 
-* Use safer frameworks that automatically escape for XSS by design, such as in Ruby 3.0 or React JS.
+* Use safer frameworks that automatically escape for XSS by design, such as in Ruby on Rails or React.
 * Escaping untrusted HTTP request data based on the context in the HTML output (body, attribute, JavaScript, CSS, or URL) will resolve Reflected and Stored XSS vulnerabilities. The [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet) has details on the required data escaping techniques.
 * Applying context sensitive encoding when modifying the browser document on the client side acts against DOM XSS. When this cannot be avoided, similar context sensitive escaping techniques can be applied to browser APIs as described in the [OWASP DOM based XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/DOM_based_XSS_Prevention_Cheat_Sheet).
 * Enabling a [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) is a defense in depth mitigating control against XSS, assuming no other vulnerabilities exist that would allow placing malicious code via local file include such as path traversal overwrites, or vulnerable libraries in permitted sources, such as content delivery network or local libraries. 


### PR DESCRIPTION
I believe there's a small error in the last RC2 in the "How Do I Prevent This?" paragraph.
Ruby 3.0 doesn't exist (version 2.4 is the latest), I believe the writer wanted to refer to Ruby on Rails 3.0 (Ruby is the general language, Ruby on Rails is a specific web framework), which started to automatically escaping unsafe input. Moreover RoR 3.0 is from august 2010, so we can now simply refer to just Ruby on Rails safely I believe.
Also React JS should be React.js (old) or simply React as it's called nowadays.